### PR TITLE
Add LayerZero randomness provider and requestor

### DIFF
--- a/src/RandomProviderA.sol
+++ b/src/RandomProviderA.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {ILayerZeroEndpoint} from "./interfaces/ILayerZeroEndpoint.sol";
+import {ILayerZeroReceiver} from "./interfaces/ILayerZeroReceiver.sol";
+import {IPythEntropy} from "./interfaces/IPythEntropy.sol";
+
+/// @notice Contract providing randomness via Pyth entropy service.
+contract RandomProviderA is ILayerZeroReceiver {
+    ILayerZeroEndpoint public immutable lzEndpoint;
+    IPythEntropy public immutable entropy;
+
+    uint16 public requestorChainId;
+    bytes public requestorAddress;
+
+    event RequestReceived(uint64 indexed id);
+    event ResponseSent(uint64 indexed id, bytes32 randomness);
+
+    constructor(address _endpoint, address _entropy, uint16 _requestorChainId, bytes memory _requestorAddress) {
+        lzEndpoint = ILayerZeroEndpoint(_endpoint);
+        entropy = IPythEntropy(_entropy);
+        requestorChainId = _requestorChainId;
+        requestorAddress = _requestorAddress;
+    }
+
+    /// @inheritdoc ILayerZeroReceiver
+    function lzReceive(
+        uint16, /* _srcChainId */
+        bytes calldata, /* _srcAddress */
+        uint64, /* _nonce */
+        bytes calldata _payload
+    ) external override {
+        require(msg.sender == address(lzEndpoint), "Not endpoint");
+        uint64 id = abi.decode(_payload, (uint64));
+        emit RequestReceived(id);
+
+        uint64 entropyId = entropy.requestRandomness();
+        bytes32 randomness = entropy.getRandomness(entropyId);
+
+        bytes memory resp = abi.encode(id, randomness);
+        lzEndpoint.send(requestorChainId, requestorAddress, resp, payable(address(this)), address(0), bytes(""));
+        emit ResponseSent(id, randomness);
+    }
+}

--- a/src/RandomRequestorB.sol
+++ b/src/RandomRequestorB.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {ILayerZeroEndpoint} from "./interfaces/ILayerZeroEndpoint.sol";
+import {ILayerZeroReceiver} from "./interfaces/ILayerZeroReceiver.sol";
+
+/// @notice Contract requesting randomness from another chain.
+contract RandomRequestorB is ILayerZeroReceiver {
+    ILayerZeroEndpoint public immutable lzEndpoint;
+
+    uint16 public providerChainId;
+    bytes public providerAddress;
+
+    uint64 public requestCount;
+
+    mapping(uint64 => bytes32) public randomResults;
+
+    event RandomRequested(uint64 indexed id);
+    event RandomReceived(uint64 indexed id, bytes32 randomness);
+
+    constructor(address _endpoint, uint16 _providerChainId, bytes memory _providerAddress) {
+        lzEndpoint = ILayerZeroEndpoint(_endpoint);
+        providerChainId = _providerChainId;
+        providerAddress = _providerAddress;
+    }
+
+    /// @notice Sends a cross-chain request for randomness.
+    function requestRandom() external payable {
+        requestCount++;
+        bytes memory payload = abi.encode(requestCount);
+        lzEndpoint.send{value: msg.value}(
+            providerChainId, providerAddress, payload, payable(msg.sender), address(0), bytes("")
+        );
+        emit RandomRequested(requestCount);
+    }
+
+    /// @inheritdoc ILayerZeroReceiver
+    function lzReceive(
+        uint16, /* _srcChainId */
+        bytes calldata, /* _srcAddress */
+        uint64, /* _nonce */
+        bytes calldata _payload
+    ) external override {
+        require(msg.sender == address(lzEndpoint), "Not endpoint");
+        (uint64 id, bytes32 randomness) = abi.decode(_payload, (uint64, bytes32));
+        randomResults[id] = randomness;
+        emit RandomReceived(id, randomness);
+    }
+}

--- a/src/interfaces/ILayerZeroEndpoint.sol
+++ b/src/interfaces/ILayerZeroEndpoint.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface ILayerZeroEndpoint {
+    function send(
+        uint16 _dstChainId,
+        bytes calldata _destination,
+        bytes calldata _payload,
+        address payable _refundAddress,
+        address _zroPaymentAddress,
+        bytes calldata _adapterParams
+    ) external payable;
+}

--- a/src/interfaces/ILayerZeroReceiver.sol
+++ b/src/interfaces/ILayerZeroReceiver.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface ILayerZeroReceiver {
+    function lzReceive(uint16 _srcChainId, bytes calldata _srcAddress, uint64 _nonce, bytes calldata _payload)
+        external;
+}

--- a/src/interfaces/IPythEntropy.sol
+++ b/src/interfaces/IPythEntropy.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+interface IPythEntropy {
+    function requestRandomness() external returns (uint64 requestId);
+    function getRandomness(uint64 requestId) external view returns (bytes32 randomness);
+}


### PR DESCRIPTION
## Summary
- implement `RandomProviderA` and `RandomRequestorB` contracts
- add LayerZero and Pyth interfaces

## Testing
- `forge fmt`
- `forge test -q` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_e_683b00fa1cc8832291906bb19e9d9c47