### PR TITLE
Add deployment script for randomness contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,34 @@ provide the id of the remote chain so that both sides can communicate.
    );
    ```
 
+### Deployment Script
+
+You can automate this setup using `RandomDeployer` from the `script` folder. The
+script deploys either contract depending on the `ROLE` environment variable and
+expects the LayerZero endpoints, chain ids and the Pyth entropy address to be
+provided as environment variables.
+
+Example for deploying the provider on Base:
+
+```bash
+ROLE=provider \
+PROVIDER_ENDPOINT=<base_lz_endpoint> \
+REQUESTOR_CHAIN_ID=<worldchain_id> \
+REQUESTOR_ADDRESS=<requestor_address> \
+PYTH_ENTROPY=<pyth_entropy_on_base> \
+forge script script/RandomDeployer.s.sol:RandomDeployer --rpc-url <base_rpc> --private-key <key>
+```
+
+To deploy the requestor on World Chain:
+
+```bash
+ROLE=requestor \
+REQUESTOR_ENDPOINT=<worldchain_lz_endpoint> \
+PROVIDER_CHAIN_ID=<base_chain_id> \
+PROVIDER_ADDRESS=<provider_address> \
+forge script script/RandomDeployer.s.sol:RandomDeployer --rpc-url <worldchain_rpc> --private-key <key>
+```
+
 ### Example Usage
 
 Calling `requestRandom` on `RandomRequestorB` sends a message to the provider.

--- a/script/RandomDeployer.s.sol
+++ b/script/RandomDeployer.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import {Script} from "forge-std/Script.sol";
+import {RandomProviderA} from "../src/RandomProviderA.sol";
+import {RandomRequestorB} from "../src/RandomRequestorB.sol";
+
+/// @notice Deploys the randomness example contracts on their respective chains.
+/// The script expects the following environment variables to be set:
+///
+/// ROLE                 - "provider" or "requestor" to choose which contract to deploy.
+/// PROVIDER_ENDPOINT    - LayerZero endpoint for the provider chain.
+/// REQUESTOR_ENDPOINT   - LayerZero endpoint for the requestor chain.
+/// PROVIDER_CHAIN_ID    - LayerZero chain id of the provider chain.
+/// REQUESTOR_CHAIN_ID   - LayerZero chain id of the requestor chain.
+/// PYTH_ENTROPY         - Pyth entropy contract address on the provider chain.
+/// PROVIDER_ADDRESS     - Address of the already deployed provider contract (required when ROLE=requestor).
+/// REQUESTOR_ADDRESS    - Address of the already deployed requestor contract (required when ROLE=provider).
+///
+/// Example usage:
+///
+/// ```bash
+/// ROLE=provider \
+/// PROVIDER_ENDPOINT=<provider lz endpoint> \
+/// REQUESTOR_CHAIN_ID=<requestor chain id> \
+/// REQUESTOR_ADDRESS=<requestor address> \
+/// PYTH_ENTROPY=<pyth entropy address on base> \
+/// forge script script/RandomDeployer.s.sol:RandomDeployer --rpc-url <base_rpc_url> --private-key <key>
+/// ```
+///
+/// ```bash
+/// ROLE=requestor \
+/// REQUESTOR_ENDPOINT=<requestor lz endpoint> \
+/// PROVIDER_CHAIN_ID=<provider chain id> \
+/// PROVIDER_ADDRESS=<provider address> \
+/// forge script script/RandomDeployer.s.sol:RandomDeployer --rpc-url <worldchain_rpc_url> --private-key <key>
+/// ```
+contract RandomDeployer is Script {
+    function run() external {
+        string memory role = vm.envString("ROLE");
+        vm.startBroadcast();
+
+        if (keccak256(bytes(role)) == keccak256("provider")) {
+            address endpoint = vm.envAddress("PROVIDER_ENDPOINT");
+            address entropy = vm.envAddress("PYTH_ENTROPY");
+            uint16 requestorChainId = uint16(vm.envUint("REQUESTOR_CHAIN_ID"));
+            address requestorAddr = vm.envAddress("REQUESTOR_ADDRESS");
+
+            new RandomProviderA(endpoint, entropy, requestorChainId, abi.encodePacked(requestorAddr));
+        } else if (keccak256(bytes(role)) == keccak256("requestor")) {
+            address endpoint = vm.envAddress("REQUESTOR_ENDPOINT");
+            uint16 providerChainId = uint16(vm.envUint("PROVIDER_CHAIN_ID"));
+            address providerAddr = vm.envAddress("PROVIDER_ADDRESS");
+
+            new RandomRequestorB(endpoint, providerChainId, abi.encodePacked(providerAddr));
+        } else {
+            revert("ROLE must be provider or requestor");
+        }
+
+        vm.stopBroadcast();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add RandomDeployer.s.sol for deploying RandomProviderA and RandomRequestorB
- document usage of the new script in README

## Testing
- `forge test` *(fails: error sending request for url https://binaries.soliditylang.org/linux-amd64/list.json)*

------
https://chatgpt.com/codex/tasks/task_e_683b07fa9f5483229476e2c88ae8e542