### PR TITLE
Add onchain SVG NFT with custom message

### DIFF
--- a/test/AjnaOracle.t.sol
+++ b/test/AjnaOracle.t.sol
@@ -71,29 +71,40 @@ contract AjnaOracleTest is Test {
     function testRedeemVoucher() public {
         bytes memory sig = _signVoucher(user, 1, block.timestamp + 1 days);
         vm.prank(user);
-        oracle.redeemVoucher(user, 1, block.timestamp + 1 days, sig, 1, "hash", "cid");
+        oracle.redeemVoucher(user, 1, block.timestamp + 1 days, sig, 1, "hash", "hello");
         assertEq(oracle.ownerOf(1), user);
     }
 
     function testRedeemVoucherNonceReuse() public {
         bytes memory sig = _signVoucher(user, 1, block.timestamp + 1 days);
         vm.prank(user);
-        oracle.redeemVoucher(user, 1, block.timestamp + 1 days, sig, 1, "hash", "cid");
+        oracle.redeemVoucher(user, 1, block.timestamp + 1 days, sig, 1, "hash", "hello");
         vm.prank(user);
         vm.expectRevert("Nonce already used");
-        oracle.redeemVoucher(user, 1, block.timestamp + 1 days, sig, 1, "hash", "cid");
+        oracle.redeemVoucher(user, 1, block.timestamp + 1 days, sig, 1, "hash", "hello");
     }
 
     function testWhitelistMinting() public {
         oracle.addToWhitelist(user);
         vm.prank(user);
-        oracle.mintWhitelisted(1, "hash", "cid");
+        oracle.mintWhitelisted(1, "hash", "hello");
         assertEq(oracle.ownerOf(1), user);
+    }
+
+    function testTokenURIOnchain() public {
+        bytes memory sig = _signVoucher(user, 2, block.timestamp + 1 days);
+        vm.prank(user);
+        oracle.redeemVoucher(user, 2, block.timestamp + 1 days, sig, 1, "hash", "hello");
+        string memory uri = oracle.tokenURI(2);
+        bytes memory prefix = bytes("data:application/json;base64,");
+        for (uint256 i = 0; i < prefix.length; i++) {
+            assertEq(bytes(uri)[i], prefix[i]);
+        }
     }
 
     function testWhitelistMintingReverts() public {
         vm.prank(user);
         vm.expectRevert("Not whitelisted");
-        oracle.mintWhitelisted(1, "hash", "cid");
+        oracle.mintWhitelisted(1, "hash", "hello");
     }
 }


### PR DESCRIPTION
## Motivation
Allow minted NFTs to include an onchain SVG image with a custom message supplied by the minter.

## What Changed
- Stored per-token message, birth hash and card ID in `AJNAOracle`
- Generated SVG and JSON metadata entirely onchain in `tokenURI`
- Updated mint functions to accept a message string
- Added tests verifying onchain tokenURI output

## How to Verify
- `forge build`
- `forge test`

*This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_e_683b806745b883229c68c9c9166b896d